### PR TITLE
refactor(flake): add overlay output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,8 @@
       inherit (nixpkgs) lib;
     };
 
-    overlay = final: prev: self.lib;
+    overlay = final: prev: import ./default.nix {
+      inherit (prev) lib;
+    };
   };
 }


### PR DESCRIPTION
This should make it easier to use this from flakes, where users can just add
this with their other overlays and have `gitignoreSource` show up in pkgs.

So this becomes possible:
```Nix
{
  outputs = { self, fenix, gitignore, nixpkgs, sbt-derivation }:
  let
    pkgs = import nixpkgs {
      overlays = [ fenix.overlay gitignore.overlay sbt-derivation.overlay ];
    };
  in
  { };
}
```

As opposed to having to manually create an overlay that just does `(_: _: inherit (gitignore.lib) gitignoreSource)`
