### PR TITLE
Make gitignoreSourceWith short-circuit

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -23,7 +23,7 @@ let
   gitignoreSourceWith = { path }:
     lib.cleanSourceWith {
       name = "source";
-      filter = find-files.gitignoreFilterWith { basePath = path.origPath or path; };
+      filter = find-files.gitignoreFilterWith { basePath = path.origSrc or path; };
       src = path;
     };
 

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -5,7 +5,6 @@ let
   ;
   in
   dimension "Nixpkgs" {
-    "nixpkgs-19_03" = sources."nixos-19.03";
     "nixpkgs-19_09" = sources."nixos-19.09";
     "nixpkgs-21_05" = sources."nixos-21.05";
   } (_key: nixpkgs:

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -11,18 +11,6 @@
         "url": "https://github.com/nmattia/niv/archive/5e9671a9a87c240b1c6ce981d04ad23ba4291451.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
-    "nixos-19.03": {
-        "branch": "nixos-19.03",
-        "description": "A read-only mirror of NixOS/nixpkgs tracking the released channels. Send issues and PRs to",
-        "homepage": "https://github.com/NixOS/nixpkgs",
-        "owner": "NixOS",
-        "repo": "nixpkgs-channels",
-        "rev": "2dfae8e22fde5032419c3027964c406508332974",
-        "sha256": "0293j9wib78n5nspywrmd9qkvcqq2vcrclrryxqnaxvj3bs1c0vj",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs-channels/archive/2dfae8e22fde5032419c3027964c406508332974.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
     "nixos-19.09": {
         "branch": "nixos-19.09",
         "description": "A read-only mirror of NixOS/nixpkgs tracking the released channels. Send issues and PRs to",

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import <nixpkgs> {}, lib ? pkgs.lib }:
 
 let
   testdata = import ./testdata.nix { inherit pkgs; };
@@ -22,19 +22,40 @@ in
   subdir-9 = runner.makeTest { name = "subdir-9"; rootDir = testdata.sourceUnfiltered + "/test-tree"; subpath = "9-expected"; };
   subdir-10 = runner.makeTest { name = "subdir-10"; rootDir = testdata.sourceUnfiltered + "/test-tree"; subpath = "10-subdir-ignoring-itself"; };
 
+  # Make sure the files aren't added to the store before filtering.
+  shortcircuit = runner.makeTest {
+    name = "nested";
+    rootDir = testdata.sourceUnfilteredRecursive + "/test-tree";
+    preCheck = ''
+      # Instead of a file, create a fifo so that the filter would error out if it tries to add it to the store.
+      rm 1-simpl/1
+      mkfifo 1-simpl/1
+    '';
+  };
+
   unit-tests =
     let gitignoreNix = import ../default.nix { inherit (pkgs) lib; };
-        inherit (gitignoreNix) gitignoreFilterWith;
+        inherit (gitignoreNix) gitignoreFilterWith gitignoreSourceWith;
         example = gitignoreFilterWith { basePath = ./.; extraRules = ''
           *.foo
           !*.bar
         ''; };
+        shortcircuit = gitignoreSourceWith {
+          path = {
+            inherit (lib.cleanSource ./.) _isLibCleanSourceWith filter name;
+            outPath = throw "do not use outPath";
+            origSrc = ./.;
+          };
+        };
     in
 
     # Test that extraRules works:
     assert example ./x.foo "regular" == false;
     assert example ./x.bar "regular" == true;
     assert example ./x.qux "regular" == true;
+
+    # Make sure outPath is not used. (It's not about the store path)
+    assert lib.hasPrefix builtins.storeDir "${shortcircuit}";
 
     # End of test. (a drv to show a buildable attr when successful)
     pkgs.emptyFile or null;


### PR DESCRIPTION
This has been broken since its introduction due to a typo. `lib.cleanSourceWith` uses the field `origSrc` to store the initial path prior to processing— which is presumably what the author intended.

With this change, `gitignoreSource (lib.sources.trace /path/to/repo)` no longer incorrectly prints ignored paths.