### PR TITLE
discard string context of git config's core.excludesFile

### DIFF
--- a/find-files.nix
+++ b/find-files.nix
@@ -242,9 +242,11 @@ rec {
         for
           (guard (toLower section == "core" && toLower key == "excludesfile"))
           (_:
-            # SAFETY: Ultimately this path will get passed into
-            # `builtins.readFile`, which ignores the context anyways. The
-            # context is only relevant if it becomes part of a derivation.
+            # Paths with context can't be appended to other paths, so we have to
+            # remove the context here.
+            # SAFETY: gitignore.nix is not responsible for making sure the
+            # store paths pointed to in your global git config have been
+            # realised.
             resolveFile (home /.) (builtins.unsafeDiscardStringContext value)
           )
       )

--- a/find-files.nix
+++ b/find-files.nix
@@ -295,7 +295,7 @@ rec {
    */
   # TODO: get something like builtins.pathType or builtins.stat into Nix
   guardFile = p: if pathExists p then [p] else [];
-  guardNonEmptyString = s: if s == "" then [s] else [];
+  guardNonEmptyString = s: if s == "" then [] else [s];
   guardNonNull = a: if a != null then a else [];
 
 

--- a/find-files.nix
+++ b/find-files.nix
@@ -242,7 +242,10 @@ rec {
         for
           (guard (toLower section == "core" && toLower key == "excludesfile"))
           (_:
-            resolveFile (home /.) value
+            # SAFETY: Ultimately this path will get passed into
+            # `builtins.readFile`, which ignores the context anyways. The
+            # context is only relevant if it becomes part of a derivation.
+            resolveFile (home /.) (builtins.unsafeDiscardStringContext value)
           )
       )
     );

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -3,6 +3,8 @@
 let
   testdata = import ./testdata.nix { inherit pkgs; };
   runner = import ./runner.nix { inherit pkgs; };
+  gitignoreNix = (import ../. { inherit lib; });
+  inherit (gitignoreNix) gitignoreSource;
 in
 {
   plain = runner.makeTest { name = "plain"; rootDir = testdata.sourceUnfiltered + "/test-tree"; };
@@ -10,10 +12,10 @@ in
 
   plain-with-testdata-dir = runner.makeTest { name = "plain"; rootDir = testdata.sourceUnfiltered; };
   nested-with-testdata-dir = runner.makeTest { name = "nested"; rootDir = testdata.sourceUnfilteredRecursive; };
-  
+
   plain-with-testdata-subdir = runner.makeTest { name = "plain"; rootDir = testdata.sourceUnfiltered; subpath = "test-tree"; };
   nested-with-testdata-subdir = runner.makeTest { name = "nested"; rootDir = testdata.sourceUnfilteredRecursive; subpath = "test-tree"; };
-  
+
   subdir-1 = runner.makeTest { name = "subdir-1"; rootDir = testdata.sourceUnfiltered + "/test-tree"; subpath = "1-simpl"; };
   subdir-1x = runner.makeTest { name = "subdir-1x"; rootDir = testdata.sourceUnfiltered + "/test-tree"; subpath = "1-xxxxx"; };
   subdir-2 = runner.makeTest { name = "subdir-2"; rootDir = testdata.sourceUnfiltered + "/test-tree"; subpath = "2-negation"; };
@@ -21,6 +23,58 @@ in
   subdir-4 = runner.makeTest { name = "subdir-4"; rootDir = testdata.sourceUnfiltered + "/test-tree"; subpath = "4-escapes"; };
   subdir-9 = runner.makeTest { name = "subdir-9"; rootDir = testdata.sourceUnfiltered + "/test-tree"; subpath = "9-expected"; };
   subdir-10 = runner.makeTest { name = "subdir-10"; rootDir = testdata.sourceUnfiltered + "/test-tree"; subpath = "10-subdir-ignoring-itself"; };
+
+  # https://github.com/hercules-ci/gitignore.nix/pull/71
+  regression-config-with-store-path =
+    let
+      excludesfile = pkgs.writeText "excludesfile" "";
+      gitconfig = pkgs.writeText "gitconfig" ''
+        [core]
+            excludesfile = ${excludesfile}
+      '';
+    in
+    pkgs.stdenv.mkDerivation {
+      name = "config-with-store-path";
+      src = testdata.sourceUnfiltered + "/test-tree";
+      buildInputs = [ pkgs.nix ];
+      NIX_PATH="nixpkgs=${pkgs.path}";
+      buildPhase = ''
+        HOME=/build/HOME
+        mkdir -p $HOME
+
+        # it must be a symlink to the nix store.
+        # that way builtins.readFile adds in the relevant context
+        ln -s ${gitconfig} $HOME/.gitconfig
+
+        export NIX_LOG_DIR=$TMPDIR
+        export NIX_STATE_DIR=$TMPDIR
+
+        echo ---------------
+
+        # outside of a nix-build, the context of this would be non-empty (replaceing the ''${} with ())
+        # inside the nix build, it's empty.
+        # Arghhhh
+
+        nix-instantiate --eval --expr --strict --json --readonly-mode --option sandbox false \
+            'let pkgs = import <nixpkgs> {}; in builtins.getContext (builtins.readFile ${pkgs.writeText "foo" (toString pkgs.hello)})'
+
+        echo ---------------
+
+        if nix-instantiate --eval --expr \
+            --readonly-mode --option sandbox false \
+            '((import ${gitignoreSource ../.} {}).gitignoreSource ./.).outPath'
+        then touch $out
+        else
+          echo
+          echo "Failed to run with a global excludes file from the nix store."
+          echo "This may be because the store path gets misinterpreted as a string context."
+          echo "See https://github.com/hercules-ci/gitignore.nix/pull/71"
+          exit 1
+        fi
+      '';
+      preInstall = "";
+      installPhase = ":";
+    };
 
   # Make sure the files aren't added to the store before filtering.
   shortcircuit = runner.makeTest {
@@ -34,8 +88,7 @@ in
   };
 
   unit-tests =
-    let gitignoreNix = import ../default.nix { inherit (pkgs) lib; };
-        inherit (gitignoreNix) gitignoreFilterWith gitignoreSourceWith;
+    let inherit (gitignoreNix) gitignoreFilterWith gitignoreSourceWith;
         example = gitignoreFilterWith { basePath = ./.; extraRules = ''
           *.foo
           !*.bar


### PR DESCRIPTION
Before this change, any store path in your git config would become part of the string context of any of the parsed strings, and then prevent us from appending it to a path.

Upon further reflection, we don't care even if `core.excludesFile` is a store path itself, so we can unconditionally throw away the string context.

I think this closes #65